### PR TITLE
Feature/template examples

### DIFF
--- a/server/database/connection.py
+++ b/server/database/connection.py
@@ -225,6 +225,7 @@ class PatientDatabase:
             raise
 
     def _migrate_to_v1(self):
+        from server.database.defaults.prompts import DEFAULT_PROMPTS
         """Initial schema setup"""
         self.cursor.execute(
             """
@@ -392,16 +393,10 @@ class PatientDatabase:
             )
         """
         )
-        # Load initial data from JSON files
-        json_path = os.path.join(
-            os.path.dirname(__file__),
-            'defaults',
-            'prompts.json'
-        )
-        with open(json_path) as f:
-            prompts_data = json.load(f)
 
-    # Initialize config with default entries
+        prompts_data = DEFAULT_PROMPTS
+
+        # Initialize config with default entries
         default_config = {
             "WHISPER_BASE_URL": "&nbsp;",
             "WHISPER_MODEL": "&nbsp;",
@@ -452,6 +447,7 @@ class PatientDatabase:
 
     def _migrate_to_v2(self):
         """Add reasoning analysis support"""
+        from server.database.defaults.prompts import DEFAULT_PROMPTS
         try:
             # Add reasoning_output column to patients table
             self.cursor.execute(
@@ -480,13 +476,7 @@ class PatientDatabase:
                 (json.dumps("&nbsp;"), json.dumps(False))
             )
 
-            json_path = os.path.join(
-                os.path.dirname(__file__),
-                'defaults',
-                'prompts.json'
-            )
-            with open(json_path) as f:
-                defaults = json.load(f)
+            defaults = DEFAULT_PROMPTS
 
             # Add new reasoning prompt
             reasoning_prompt = defaults["prompts"]["reasoning"]["system"]

--- a/server/database/defaults/prompts.py
+++ b/server/database/defaults/prompts.py
@@ -1,4 +1,4 @@
-{
+DEFAULT_PROMPTS = {
     "prompts": {
         "refinement": {
             "system": "You are an editing assistant. The user will send you a summary with which you will perform the following:\n1. Remove any phrases like 'doctor says' or 'patient says'.\n2. Brevity is key. For example, replace 'Patient feels tired', with 'feels tired'; instead of \"Follow-up appointment to review blood tests in 6 months time\" just say \"Review in 6 months with bloods\"\n3. Avoid using phrases like 'the doctor' or 'the patient'.\n4. Do not change the formatting of the input. It must remain in dot points, numbered list, narrative prose, or whatever format it was initially provided in.\n5. Use Australian medical abbreviations where possible.\n\nThe summary you provide will be for the doctor's own records."

--- a/server/database/defaults/templates.py
+++ b/server/database/defaults/templates.py
@@ -17,7 +17,8 @@ class DefaultTemplates:
             "format_schema": {
                 "type": "numbered"
             },
-            "refinement_rules": ["default"]
+            "refinement_rules": ["default"],
+            "style_example": "1. Check CBC, LFTs, coags in 2 weeks\n2. Refer to dermatology for skin assessment\n3. FU in clinic in 4 weeks with results\n4. Book PET scan to reassess disease status"
         }
 
     @classmethod
@@ -34,7 +35,8 @@ class DefaultTemplates:
                         "field_type": "text",
                         "persistent": True,
                         "system_prompt": "Extract and summarize the primary haematological condition and its history.",
-                        "initial_prompt": "# Primary Condition\n-"
+                        "initial_prompt": "# Primary Condition\n-",
+                        "style_example": "# Chronic lymphocytic leukemia\n- Diagnosed Aug 2021\n- Initial presentation with lymphocytosis on routine bloods\n- Previously treated with FCR x 6 cycles with good response"
                     },
                     {
                         "field_key": "additional_history",
@@ -42,7 +44,8 @@ class DefaultTemplates:
                         "field_type": "text",
                         "persistent": True,
                         "system_prompt": "List other active medical problems.",
-                        "initial_prompt": "# Other Active Problems\n-"
+                        "initial_prompt": "# Other Active Problems\n-",
+                        "style_example": "#Hypertension\n- Controlled on amlodipine 5mg OD\n#Type 2 diabetes - HbA1c 6.8% (Mar 2023)\n# Previous DVT (2019)\n- completed anticoagulation"
                     },
                     {
                         "field_key": "investigations",
@@ -50,7 +53,8 @@ class DefaultTemplates:
                         "field_type": "text",
                         "persistent": True,
                         "system_prompt": "Extract and format investigation results.",
-                        "initial_prompt": "Results:\n"
+                        "initial_prompt": "Results:\n",
+                        "style_example": "Hb 120 g/L (↓), WCC 15.2 x10^9/L (↑), Plts 145 x10^9/L\nLymphocytes 12.4 x10^9/L (↑)\nCreat 82 μmol/L, eGFR >90 mL/min\nLFTs normal\nPET scan (Mar 2023): No evidence of disease progression"
                     },
                     {
                         "field_key": "clinical_history",
@@ -62,7 +66,8 @@ class DefaultTemplates:
                             "type": "bullet",
                         },
                         "initial_prompt": "Current Status:\n-",
-                        "system_prompt": "You are a professional transcript summarisation assistant. The user will send you a raw transcript with which you will perform the following:\n1. Summarise and present the key points from the clinical encounter.\n2. Tailor your summary based on the context. If this is a new patient, then focus on the history of the presenting complaint; for returning patients focus on current signs and symptoms.\n3. Report any examination findings (but only if it clear that one was performed).\n4. The target audience of the text is medical professionals so use jargon and common Australian medical abbreviations where appropriate.\n5. Do not include any items regarding the ongoing plan. Only include items regarding to the patient's HOPC and examination.\n6. Try to include at least 5 distinct dot points in the summary. Include more if required. Pay particular attention to discussion regarding constitutional symptoms, pains, and pertinent negatives on questioning."
+                        "system_prompt": "You are a professional transcript summarisation assistant. The user will send you a raw transcript with which you will perform the following:\n1. Summarise and present the key points from the clinical encounter.\n2. Tailor your summary based on the context. If this is a new patient, then focus on the history of the presenting complaint; for returning patients focus on current signs and symptoms.\n3. Report any examination findings (but only if it clear that one was performed).\n4. The target audience of the text is medical professionals so use jargon and common medical abbreviations where appropriate.\n5. Do not include any items regarding the ongoing plan. Only include items regarding to the patient's HOPC and examination.\n6. Try to include at least 5 distinct dot points in the summary. Include more if required. Pay particular attention to discussion regarding constitutional symptoms, pains, and pertinent negatives on questioning.",
+                        "style_example": "- Presents with a lump in the neck, first noticed approximately 3 weeks prior\n- No significant change in size since then\n- No associated symptoms such as fevers, sweats, or weight loss reported\n- Denies other new lumps or bumps and is otherwise feeling well\n- Lymph node approximately 1 cm in size on examination today\n- No other palpable lymph nodes found. Abdo SNT; no HSM"
                     },
                     {
                         "field_key": "impression",
@@ -71,6 +76,7 @@ class DefaultTemplates:
                         "persistent": True,
                         "system_prompt": "Provide a clinical impression of the current status.",
                         "initial_prompt": "Impression: ",
+                        "style_example": "Stable CLL with good response to previous therapy. Recent counts show mild lymphocytosis but no evidence of disease progression. Remains clinically well with no B symptoms."
                     },
                     cls.get_plan_field()  # Add standard plan field
                 ]
@@ -90,6 +96,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
+                        "style_example": "S:\n- 45yo F presents with 2 week Hx of worsening SOB\n- Reports difficulty climbing stairs and walking >100m\n- Associated with non-productive cough, worse at night\n- No fever, chest pain, or hemoptysis\n- PMHx: Asthma (diagnosed age 12), well controlled until recent exacerbation\n- Meds: Salbutamol PRN (using 6-8 puffs/day recently, up from 2-3/week)"
                     },
                     {
                         "field_key": "objective",
@@ -102,6 +109,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
+                        "style_example": "O:\n- Vitals: HR 92, BP 132/78, T 37.1, RR 20, O2 sat 95% RA\n- Alert, mild respiratory distress with speech\n- Chest: Bilateral expiratory wheeze, prolonged expiratory phase\n- No accessory muscle use, no cyanosis\n- PEFR: 280 L/min (predicted 420 L/min)\n- CXR: Hyperinflation, no infiltrates or consolidation"
                     },
                     {
                         "field_key": "assessment",
@@ -114,6 +122,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
+                        "style_example": "A:\n- Moderate asthma exacerbation\n- Likely triggered by recent respiratory infection\n- Suboptimal control with current medication regimen\n- No signs of pneumonia or other complications at this time"
                     },
                     cls.get_plan_field()  # Add standard plan field
                 ]
@@ -133,6 +142,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
+                        "style_example": "Interval History:\n- Last seen 3 months ago for AML post-induction\n- Completed consolidation cycle 2 weeks ago\n- Initially tolerated well but developed neutropenic fever day +10\n- Admitted for 5 days, treated with IV antibiotics\n- Blood cultures negative, resp viral panel +ve for rhinovirus"
                     },
                     {
                         "field_key": "current_status",
@@ -145,6 +155,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
+                        "style_example": "Current Status:\n- Now day +21 post-chemo, feeling much improved\n- Ongoing fatigue but able to perform ADLs independently\n- Appetite returning, regained 1kg since discharge\n- No fevers, night sweats, or bleeding\n- Latest FBC shows count recovery with ANC 1.2, Hb 105, Plts 75\n- Examination: No significant findings. ECOG PS 1"
                     },
                     cls.get_plan_field()  # Add standard plan field
                 ]

--- a/server/database/defaults/templates.py
+++ b/server/database/defaults/templates.py
@@ -52,9 +52,9 @@ class DefaultTemplates:
                         "field_name": "Investigations",
                         "field_type": "text",
                         "persistent": True,
-                        "system_prompt": "Extract and format investigation results.",
+                        "system_prompt": "Extract and format investigation results in the following format. Only include the most recent investigations:\n<Name of pathology company (eg Dorevitch)> <Date of test DD/MM/YY>:\nFBE Hb/WCC/Plt\n\nUEC Na/K/Cr (eGFR)\n\nOther relevant investigations such as calcium level.\n\nRelevant imaging should appear like so:\n<Type of scan eg CT-Brain> <Imaging Company eg Lumus> <Date of scan DD/MM/YY>\n- <key point from scan report>",
                         "initial_prompt": "Results:\n",
-                        "style_example": "Hb 120 g/L (↓), WCC 15.2 x10^9/L (↑), Plts 145 x10^9/L\nLymphocytes 12.4 x10^9/L (↑)\nCreat 82 μmol/L, eGFR >90 mL/min\nLFTs normal\nPET scan (Mar 2023): No evidence of disease progression"
+                        "style_example": "Melbourne Pathology 15/06/23:\nFBE Hb 120/WCC 15.2/Plt 145\n\nUEC Na 138/K 4.2/Cr 82 (eGFR >90)\n\nLFTs normal\nCalcium 2.35\n\nPET-CT Melbourne Imaging 28/03/23:\n- No evidence of disease progression\n- No new FDG-avid lesions identified"
                     },
                     {
                         "field_key": "clinical_history",

--- a/server/database/defaults/templates.py
+++ b/server/database/defaults/templates.py
@@ -96,7 +96,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
-                        "style_example": "S:\n- 45yo F presents with 2 week Hx of worsening SOB\n- Reports difficulty climbing stairs and walking >100m\n- Associated with non-productive cough, worse at night\n- No fever, chest pain, or hemoptysis\n- PMHx: Asthma (diagnosed age 12), well controlled until recent exacerbation\n- Meds: Salbutamol PRN (using 6-8 puffs/day recently, up from 2-3/week)"
+                        "style_example": "- 45yo F presents with 2 week Hx of worsening SOB\n- Reports difficulty climbing stairs and walking >100m\n- Associated with non-productive cough, worse at night\n- No fever, chest pain, or hemoptysis\n- PMHx: Asthma (diagnosed age 12), well controlled until recent exacerbation\n- Meds: Salbutamol PRN (using 6-8 puffs/day recently, up from 2-3/week)"
                     },
                     {
                         "field_key": "objective",
@@ -109,7 +109,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
-                        "style_example": "O:\n- Vitals: HR 92, BP 132/78, T 37.1, RR 20, O2 sat 95% RA\n- Alert, mild respiratory distress with speech\n- Chest: Bilateral expiratory wheeze, prolonged expiratory phase\n- No accessory muscle use, no cyanosis\n- PEFR: 280 L/min (predicted 420 L/min)\n- CXR: Hyperinflation, no infiltrates or consolidation"
+                        "style_example": "- Vitals: HR 92, BP 132/78, T 37.1, RR 20, O2 sat 95% RA\n- Alert, mild respiratory distress with speech\n- Chest: Bilateral expiratory wheeze, prolonged expiratory phase\n- No accessory muscle use, no cyanosis\n- PEFR: 280 L/min (predicted 420 L/min)\n- CXR: Hyperinflation, no infiltrates or consolidation"
                     },
                     {
                         "field_key": "assessment",
@@ -122,7 +122,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
-                        "style_example": "A:\n- Moderate asthma exacerbation\n- Likely triggered by recent respiratory infection\n- Suboptimal control with current medication regimen\n- No signs of pneumonia or other complications at this time"
+                        "style_example": "- Moderate asthma exacerbation\n- Likely triggered by recent respiratory infection\n- Suboptimal control with current medication regimen\n- No signs of pneumonia or other complications at this time"
                     },
                     cls.get_plan_field()  # Add standard plan field
                 ]
@@ -142,7 +142,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
-                        "style_example": "Interval History:\n- Last seen 3 months ago for AML post-induction\n- Completed consolidation cycle 2 weeks ago\n- Initially tolerated well but developed neutropenic fever day +10\n- Admitted for 5 days, treated with IV antibiotics\n- Blood cultures negative, resp viral panel +ve for rhinovirus"
+                        "style_example": "- Last seen 3 months ago for AML post-induction\n- Completed consolidation cycle 2 weeks ago\n- Initially tolerated well but developed neutropenic fever day +10\n- Admitted for 5 days, treated with IV antibiotics\n- Blood cultures negative, resp viral panel +ve for rhinovirus"
                     },
                     {
                         "field_key": "current_status",
@@ -155,7 +155,7 @@ class DefaultTemplates:
                             "bullet_char": "-",
                             "type": "bullet",
                         },
-                        "style_example": "Current Status:\n- Now day +21 post-chemo, feeling much improved\n- Ongoing fatigue but able to perform ADLs independently\n- Appetite returning, regained 1kg since discharge\n- No fevers, night sweats, or bleeding\n- Latest FBC shows count recovery with ANC 1.2, Hb 105, Plts 75\n- Examination: No significant findings. ECOG PS 1"
+                        "style_example": "- Now day +21 post-chemo, feeling much improved\n- Ongoing fatigue but able to perform ADLs independently\n- Appetite returning, regained 1kg since discharge\n- No fevers, night sweats, or bleeding\n- Latest FBC shows count recovery with ANC 1.2, Hb 105, Plts 75\n- Examination: No significant findings. ECOG PS 1"
                     },
                     cls.get_plan_field()  # Add standard plan field
                 ]

--- a/server/schemas/templates.py
+++ b/server/schemas/templates.py
@@ -20,6 +20,7 @@ class TemplateField(BaseModel):
     system_prompt: str
     initial_prompt: str
     format_schema: Optional[dict] = None
+    style_example: Optional[str] = None
     refinement_rules: Optional[List[str]] = None
 
     @validator('field_type')
@@ -28,6 +29,7 @@ class TemplateField(BaseModel):
         if v not in valid_types:
             raise ValueError(f"field_type must be one of {valid_types}")
         return v
+
 
 class ClinicalTemplate(BaseModel):
     template_key: str

--- a/server/schemas/templates.py
+++ b/server/schemas/templates.py
@@ -18,9 +18,9 @@ class TemplateField(BaseModel):
     required: bool = False
     persistent: bool = False
     system_prompt: str
-    initial_prompt: str
+    initial_prompt: Optional[str] = None
     format_schema: Optional[dict] = None
-    style_example: Optional[str] = None
+    style_example: str
     refinement_rules: Optional[List[str]] = None
 
     @validator('field_type')
@@ -64,6 +64,7 @@ class TemplateSectionSchema(BaseModel):
     format_style: FormatStyle
     bullet_type: Optional[str] = None
     section_starter: str
+    example_text: str
     persistent: bool = False
     required: bool = False
 

--- a/server/utils/chat.py
+++ b/server/utils/chat.py
@@ -188,10 +188,8 @@ class ChatEngine:
                         "description": "Use this tool ONLY if the user explicitly asks about something from the transcript, interview, or conversation with the patient. This will search the transcript for relevant information.",
                         "parameters": {
                             "type": "object",
-                            "properties": {
-                                "query": {"type": "string", "description": "The specific question or information to extract from the transcript"},
-                            },
-                            "required": ["query"],
+                            "properties": {},
+                            "required": [],
                         },
                     },
                 },
@@ -264,11 +262,11 @@ class ChatEngine:
                         if 'message' in chunk and 'content' in chunk['message']:
                             yield {"type": "chunk", "content": chunk['message']['content']}
                 else:
-                    self.logger.info(f"Searching transcript for query: {tool['function']['arguments']['query'][:50]}...")
+                    self.logger.info("Searching transcript for query...")
                     yield {"type": "status", "content": "Searching through transcript..."}
 
                     # Create a query to extract information from the transcript
-                    query = tool["function"]["arguments"]["query"]
+                    query = conversation_history[-1]["content"]
 
                     # Create a new message list with the transcript and query
                     transcript_query_messages = [

--- a/server/utils/transcription.py
+++ b/server/utils/transcription.py
@@ -43,7 +43,7 @@ async def transcribe_audio(audio_buffer: bytes) -> Dict[str, Union[str, float]]:
             form_data.add_field("language", "en")
             form_data.add_field("temperature", "0.1")
             form_data.add_field("vad_filter", "true")
-            form_data.add_field("response_format", "json")
+            form_data.add_field("response_format", "verbose_json")
             form_data.add_field("timestamp_granularities[]", "segment")
 
             transcription_start = time.perf_counter()

--- a/server/utils/transcription.py
+++ b/server/utils/transcription.py
@@ -6,8 +6,9 @@ import logging
 from typing import Dict, List, Union
 from ollama import AsyncClient as AsyncOllamaClient
 from server.database.config import config_manager
+from server.utils.helpers import refine_field_content
 from server.schemas.templates import TemplateField, TemplateResponse
-from server.schemas.grammars import FieldResponse, RefinedResponse
+from server.schemas.grammars import FieldResponse
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -224,55 +225,6 @@ def clean_list_spacing(text: str) -> str:
     text = re.sub(r'^\s{2,}', ' ', text)
     return text.strip()
 
-async def refine_field_content(
-    content: Union[str, Dict],
-    field: TemplateField
-) -> Union[str, Dict]:
-    """
-    Refine the content of a single field using style examples and format schema.
-
-    Args:
-        content (Union[str, Dict]): The raw content to refine.
-        field (TemplateField): The field being processed.
-
-    Returns:
-        Union[str, Dict]: The refined content.
-    """
-    try:
-        # If content is already structured (dict), return as is
-        if isinstance(content, dict):
-            return content
-
-        # Get configuration and client
-        config = config_manager.get_config()
-        client = AsyncOllamaClient(host=config["OLLAMA_BASE_URL"])
-        prompts = config_manager.get_prompts_and_options()
-        options = prompts["options"]["general"]
-
-        # Determine format details
-        format_details = _determine_format_details(field, prompts)
-
-        # Build system prompt with style example if available
-        system_prompt = _build_system_prompt(field, format_details, prompts)
-
-        # Execute the model call
-        response = await client.chat(
-            model=config["PRIMARY_MODEL"],
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": content},
-            ],
-            format=format_details["response_format"],
-            options=options
-        )
-
-        # Format the response appropriately
-        return _format_refined_response(response, field, format_details)
-
-    except Exception as e:
-        logger.error(f"Error refining field {field.field_key}: {e}")
-        raise
-
 def _build_patient_context(context: Dict[str, str]) -> str:
     """
     Build patient context string from dictionary.
@@ -334,113 +286,3 @@ def _detect_audio_format(audio_buffer):
         return "recording.m4a", "audio/mp4"
     # Default to WAV if we can't determine
     return "recording.wav", "audio/wav"
-
-def _determine_format_details(field: TemplateField, prompts: dict) -> dict:
-    """Determine response format and format type based on field schema."""
-    format_type = None
-    if field.format_schema and "type" in field.format_schema:
-        format_type = field.format_schema["type"]
-
-        if format_type == "narrative":
-            return {
-                "format_type": "narrative",
-                "response_format": NarrativeResponse.model_json_schema(),
-                "base_prompt": "Format the following content as a cohesive narrative paragraph."
-            }
-
-    # Default to RefinedResponse for non-narrative formats
-    format_guidance = ""
-    if format_type == "numbered":
-        format_guidance = "Format the key points as a numbered list (1., 2., etc.)."
-    elif format_type == "bullet":
-        format_guidance = "Format the key points as a bulleted list (•) prefixes)."
-
-    return {
-        "format_type": format_type,
-        "response_format": RefinedResponse.model_json_schema(),
-        "base_prompt": prompts["prompts"]["refinement"]["system"],
-        "format_guidance": format_guidance
-    }
-
-def _build_system_prompt(field: TemplateField, format_details: dict, prompts: dict) -> str:
-    """Build the system prompt using format guidance and style examples."""
-    # Check if field has style_example and prioritize it
-    if hasattr(field, 'style_example') and field.style_example:
-        return f"""
-        You are an expert medical scribe. Your task is to reformat medical information to precisely match the style example provided, while maintaining clinical accuracy.
-
-        STYLE EXAMPLE:
-        {field.style_example}
-
-        FORMATTING INSTRUCTIONS:
-        1. Analyze the STYLE EXAMPLE and match it EXACTLY, including:
-        - Format elements (bullet style, indentation, paragraph structure)
-        - Sentence structure (fragments vs. complete sentences)
-        - Capitalization and punctuation patterns
-        - Abbreviation conventions and medical terminology style
-        - Tense (past/present) and perspective (first/third person)
-
-        2. IMPORTANT CONSTRAINTS:
-        - Preserve ALL clinical details and values from the original text
-        - Do not add information not present in the input
-        - RETURN JSON IN THE REQUESTED FORMAT
-        - If the style example uses abbreviations like "SNT" or "HSM", use similar appropriate medical abbreviations
-
-        FORMAT THE FOLLOWING MEDICAL INFORMATION:"""
-
-    # If no style example, start with base prompt
-    system_prompt = format_details["base_prompt"]
-
-    # Add format guidance if available
-    if "format_guidance" in format_details and format_details["format_guidance"]:
-        system_prompt += "\n" + format_details["format_guidance"]
-
-    # Apply custom refinement rules if specified and no style example exists
-    if field.refinement_rules:
-        for rule in field.refinement_rules:
-            if rule in prompts["prompts"]["refinement"]:
-                system_prompt = prompts["prompts"]["refinement"][rule]
-                break
-    print(system_prompt)
-    return system_prompt
-
-def _format_refined_response(response: dict, field: TemplateField, format_details: dict) -> str:
-    """Format the model response according to field requirements."""
-    format_type = format_details["format_type"]
-
-    if format_type == "narrative":
-        narrative_response = NarrativeResponse.model_validate_json(response['message']['content'])
-        return narrative_response.narrative
-
-    # Handle non-narrative formats
-    refined_response = RefinedResponse.model_validate_json(response['message']['content'])
-
-    if format_type == "numbered":
-        return _format_numbered_list(refined_response.key_points)
-    elif format_type == "bullet":
-        return _format_bulleted_list(refined_response.key_points, field)
-    else:
-        # No specific formatting required
-        return "\n".join(refined_response.key_points)
-
-def _format_numbered_list(key_points: List[str]) -> str:
-    """Format key points as a numbered list."""
-    formatted_key_points = []
-    for i, point in enumerate(key_points):
-        # Strip any existing numbering
-        cleaned_point = re.sub(r'^\d+\.\s*', '', point.strip())
-        formatted_key_points.append(f"{i+1}. {cleaned_point}")
-    return "\n".join(formatted_key_points)
-
-def _format_bulleted_list(key_points: List[str], field: TemplateField) -> str:
-    """Format key points as a bulleted list."""
-    bullet_char = "•"  # Default bullet character
-    if field.format_schema and "bullet_char" in field.format_schema:
-        bullet_char = field.format_schema["bullet_char"]
-
-    formatted_key_points = []
-    for point in key_points:
-        # Strip any existing bullets
-        cleaned_point = re.sub(r'^[•\-\*]\s*', '', point.strip())
-        formatted_key_points.append(f"{bullet_char} {cleaned_point}")
-    return "\n".join(formatted_key_points)

--- a/src/components/settings/ChatSettingsPanel.js
+++ b/src/components/settings/ChatSettingsPanel.js
@@ -135,7 +135,7 @@ const ChatSettingsPanel = ({
                                                         e.target.value,
                                                     )
                                                 }
-                                                className="textarea-style"
+                                                className="input-style"
                                                 placeholder="Prompt sent to AI"
                                                 rows={4}
                                             />
@@ -213,7 +213,7 @@ const ChatSettingsPanel = ({
                                                         e.target.value,
                                                     )
                                                 }
-                                                className="textarea-style"
+                                                className="input-style"
                                                 placeholder="Prompt sent to AI"
                                                 rows={4}
                                             />
@@ -291,7 +291,7 @@ const ChatSettingsPanel = ({
                                                         e.target.value,
                                                     )
                                                 }
-                                                className="textarea-style"
+                                                className="input-style"
                                                 placeholder="Prompt sent to AI"
                                                 rows={4}
                                             />

--- a/src/components/settings/TemplateEditor.js
+++ b/src/components/settings/TemplateEditor.js
@@ -33,9 +33,6 @@ import { colors } from "../../theme/colors";
 
 const FieldEditor = ({ field, idx, updateField, removeField }) => {
     const [showAdvanced, setShowAdvanced] = useState(false);
-    // New state for showing system prompt for persistent fields
-    const [showPersistentSystemPrompt, setShowPersistentSystemPrompt] =
-        useState(false);
     const isPlanField = field.field_name?.toLowerCase() === "plan";
 
     return (
@@ -180,303 +177,173 @@ const FieldEditor = ({ field, idx, updateField, removeField }) => {
                 </HStack>
             </Flex>
             <VStack spacing={3} align="stretch">
-                {/* For persistent fields, show a button to expose system prompt */}
-                {field.persistent && (
-                    <Box mt={4}>
-                        <Button
-                            size="sm"
-                            variant="outline"
-                            leftIcon={
-                                showPersistentSystemPrompt ? (
-                                    <ChevronDownIcon />
-                                ) : (
-                                    <ChevronRightIcon />
-                                )
-                            }
-                            onClick={() =>
-                                setShowPersistentSystemPrompt(
-                                    !showPersistentSystemPrompt,
-                                )
-                            }
-                            mb={2}
-                        >
-                            {showPersistentSystemPrompt ? "Hide" : "Show"}{" "}
+                {/* System prompt for all fields (persistent and dynamic) */}
+                <Tooltip label="Instructions for the AI on how to process this field">
+                    <Box width="full" mt={4}>
+                        <Text fontSize="sm" mb={1}>
                             System Prompt
-                        </Button>
+                        </Text>
+                        <Textarea
+                            value={field.system_prompt || ""}
+                            rows={6}
+                            onChange={(e) =>
+                                updateField(
+                                    idx,
+                                    "system_prompt",
+                                    e.target.value,
+                                )
+                            }
+                            sx={{ overflowY: "auto !important" }}
+                            style={{
+                                lineHeight: "1.5",
+                                overflowY: "auto !important",
+                            }}
+                            className="input-style"
+                            placeholder={
+                                field.persistent
+                                    ? "Enter system prompt for this persistent field..."
+                                    : "Enter system prompt for this dynamic field..."
+                            }
+                        />
+                    </Box>
+                </Tooltip>
 
-                        <Collapse
-                            in={showPersistentSystemPrompt}
-                            animateOpacity
-                        >
-                            <Box width="full">
-                                <Text fontSize="sm" mb={1}>
-                                    System Prompt
-                                </Text>
-                                <Tooltip label="Instructions for the AI on how to process this persistent field (for example, in document processing)">
+                {/* Advanced settings for both persistent and dynamic fields */}
+                <Box mt="4">
+                    <IconButton
+                        icon={
+                            showAdvanced ? (
+                                <ChevronDownIcon />
+                            ) : (
+                                <ChevronRightIcon />
+                            )
+                        }
+                        onClick={() => setShowAdvanced(!showAdvanced)}
+                        aria-label="Toggle Advanced Settings"
+                        variant="outline"
+                        size="10"
+                        mr="2"
+                        className="collapse-toggle"
+                    />
+                    <Text fontSize="sm" mb="1" mt="4" display="inline">
+                        Advanced Settings
+                    </Text>
+                    <Collapse in={showAdvanced} animateOpacity>
+                        <VStack spacing={3} mt="4">
+                            <Tooltip label="Specify the format structure for the response">
+                                <Box width="full">
+                                    <Text fontSize="sm" mb={1}>
+                                        Format Schema
+                                    </Text>
+                                    <Select
+                                        size="sm"
+                                        className="input-style"
+                                        value={
+                                            field.format_schema?.type || "none"
+                                        }
+                                        onChange={(e) => {
+                                            const value = e.target.value;
+                                            if (value === "none") {
+                                                updateField(
+                                                    idx,
+                                                    "format_schema",
+                                                    null,
+                                                );
+                                            } else {
+                                                let schema = {
+                                                    type: value,
+                                                };
+                                                if (value === "bullet") {
+                                                    schema.bullet_char = "•"; // Default bullet
+                                                }
+                                                updateField(
+                                                    idx,
+                                                    "format_schema",
+                                                    schema,
+                                                );
+                                            }
+                                        }}
+                                    >
+                                        <option value="none">Free Text</option>
+                                        <option value="bullet">
+                                            Bullet List
+                                        </option>
+                                        <option value="numbered">
+                                            Numbered List
+                                        </option>
+                                        <option value="narrative">
+                                            Narrative Paragraph
+                                        </option>
+                                    </Select>
+
+                                    {/* Show bullet character selector if bullet format is selected */}
+                                    {field.format_schema?.type === "bullet" && (
+                                        <Box mt={2}>
+                                            <Text fontSize="sm" mb={1}>
+                                                Bullet Character
+                                            </Text>
+                                            <Select
+                                                size="sm"
+                                                className="input-style"
+                                                value={
+                                                    field.format_schema
+                                                        ?.bullet_char || "•"
+                                                }
+                                                onChange={(e) => {
+                                                    updateField(
+                                                        idx,
+                                                        "format_schema",
+                                                        {
+                                                            ...field.format_schema,
+                                                            bullet_char:
+                                                                e.target.value,
+                                                        },
+                                                    );
+                                                }}
+                                            >
+                                                <option value="•">
+                                                    • (Bullet)
+                                                </option>
+                                                <option value="-">
+                                                    - (Dash)
+                                                </option>
+                                                <option value="*">
+                                                    * (Asterisk)
+                                                </option>
+                                                <option value="→">
+                                                    → (Arrow)
+                                                </option>
+                                            </Select>
+                                        </Box>
+                                    )}
+                                </Box>
+                            </Tooltip>
+
+                            {/* Add the Style Example field */}
+                            <Tooltip label="Example of how this field should look">
+                                <Box width="full">
+                                    <Text fontSize="sm" mb={1}>
+                                        Style Example
+                                    </Text>
                                     <Textarea
-                                        value={field.system_prompt || ""}
-                                        rows={6}
-                                        onChange={(e) =>
+                                        size="sm"
+                                        value={field.style_example || ""}
+                                        onChange={(e) => {
                                             updateField(
                                                 idx,
-                                                "system_prompt",
+                                                "style_example",
                                                 e.target.value,
-                                            )
-                                        }
-                                        sx={{ overflowY: "auto !important" }}
-                                        style={{
-                                            lineHeight: "1.5",
-                                            overflowY: "auto !important",
+                                            );
                                         }}
-                                        className="textarea-style"
-                                        placeholder="Enter system prompt for this persistent field (for example, in document processing)..."
+                                        className="input-style"
+                                        placeholder="Enter an example of how this field should be formatted..."
+                                        rows={4}
                                     />
-                                </Tooltip>
-                            </Box>
-                        </Collapse>
-                    </Box>
-                )}
-
-                {/* For dynamic fields, show all the existing fields */}
-                {!field.persistent && (
-                    <>
-                        <Tooltip label="The type of content this field will contain"></Tooltip>
-                        <Tooltip label="Instructions for the AI on how to process this field">
-                            <Box width="full">
-                                <Text fontSize="sm" mb={1}>
-                                    System Prompt
-                                </Text>
-                                <Textarea
-                                    value={field.system_prompt || ""}
-                                    rows={6}
-                                    onChange={(e) =>
-                                        updateField(
-                                            idx,
-                                            "system_prompt",
-                                            e.target.value,
-                                        )
-                                    }
-                                    sx={{ overflowY: "auto !important" }}
-                                    style={{
-                                        lineHeight: "1.5",
-                                        overflowY: "auto !important",
-                                    }}
-                                    className="textarea-style"
-                                />
-                            </Box>
-                        </Tooltip>
-
-                        <Box mt="4">
-                            <IconButton
-                                icon={
-                                    showAdvanced ? (
-                                        <ChevronDownIcon />
-                                    ) : (
-                                        <ChevronRightIcon />
-                                    )
-                                }
-                                onClick={() => setShowAdvanced(!showAdvanced)}
-                                aria-label="Toggle Advanced Settings"
-                                variant="outline"
-                                size="10"
-                                mr="2"
-                                className="collapse-toggle"
-                            />
-                            <Text fontSize="sm" mb="1" mt="4" display="inline">
-                                Advanced Settings
-                            </Text>
-                            <Collapse in={showAdvanced} animateOpacity>
-                                <VStack spacing={3} mt="4">
-                                    <Tooltip label="Initial text to guide the AI's response format">
-                                        <Box width="full">
-                                            <Text fontSize="sm" mb={1}>
-                                                Initial Prompt
-                                            </Text>
-                                            <Textarea
-                                                size="sm"
-                                                value={
-                                                    field.initial_prompt
-                                                        ? field.initial_prompt.replace(
-                                                              /\n/g,
-                                                              "\\n",
-                                                          )
-                                                        : ""
-                                                }
-                                                onChange={(e) => {
-                                                    // Replace \\n with actual newlines when saving
-                                                    const value =
-                                                        e.target.value.replace(
-                                                            /\\n/g,
-                                                            "\n",
-                                                        );
-                                                    updateField(
-                                                        idx,
-                                                        "initial_prompt",
-                                                        value,
-                                                    );
-                                                }}
-                                                className="textarea-style"
-                                            />
-                                        </Box>
-                                    </Tooltip>
-                                    <Tooltip label="Specify the format structure for the response">
-                                        <Box width="full">
-                                            <Text fontSize="sm" mb={1}>
-                                                Format Schema
-                                            </Text>
-                                            <Select
-                                                size="sm"
-                                                className="input-style"
-                                                value={
-                                                    field.format_schema?.type ||
-                                                    "none"
-                                                }
-                                                onChange={(e) => {
-                                                    const value =
-                                                        e.target.value;
-                                                    if (value === "none") {
-                                                        updateField(
-                                                            idx,
-                                                            "format_schema",
-                                                            null,
-                                                        );
-                                                    } else {
-                                                        let schema = {
-                                                            type: value,
-                                                        };
-                                                        if (
-                                                            value === "bullet"
-                                                        ) {
-                                                            schema.bullet_char =
-                                                                "•"; // Default bullet
-                                                        }
-                                                        updateField(
-                                                            idx,
-                                                            "format_schema",
-                                                            schema,
-                                                        );
-                                                    }
-                                                }}
-                                            >
-                                                <option value="none">
-                                                    Free Text
-                                                </option>
-                                                <option value="bullet">
-                                                    Bullet List
-                                                </option>
-                                                <option value="numbered">
-                                                    Numbered List
-                                                </option>
-                                                <option value="narrative">
-                                                    Narrative Paragraph
-                                                </option>
-                                            </Select>
-
-                                            {/* Show bullet character selector if bullet format is selected */}
-                                            {field.format_schema?.type ===
-                                                "bullet" && (
-                                                <Box mt={2}>
-                                                    <Text fontSize="sm" mb={1}>
-                                                        Bullet Character
-                                                    </Text>
-                                                    <Select
-                                                        size="sm"
-                                                        className="input-style"
-                                                        value={
-                                                            field.format_schema
-                                                                ?.bullet_char ||
-                                                            "•"
-                                                        }
-                                                        onChange={(e) => {
-                                                            updateField(
-                                                                idx,
-                                                                "format_schema",
-                                                                {
-                                                                    ...field.format_schema,
-                                                                    bullet_char:
-                                                                        e.target
-                                                                            .value,
-                                                                },
-                                                            );
-                                                        }}
-                                                    >
-                                                        <option value="•">
-                                                            • (Bullet)
-                                                        </option>
-                                                        <option value="-">
-                                                            - (Dash)
-                                                        </option>
-                                                        <option value="*">
-                                                            * (Asterisk)
-                                                        </option>
-                                                        <option value="→">
-                                                            → (Arrow)
-                                                        </option>
-                                                    </Select>
-                                                </Box>
-                                            )}
-                                        </Box>
-                                    </Tooltip>
-
-                                    {/* Add the new Style Example field here */}
-                                    <Tooltip label="Example of how this field should look">
-                                        <Box width="full">
-                                            <Text fontSize="sm" mb={1}>
-                                                Style Example
-                                            </Text>
-                                            <Textarea
-                                                size="sm"
-                                                value={
-                                                    field.style_example || ""
-                                                }
-                                                onChange={(e) => {
-                                                    updateField(
-                                                        idx,
-                                                        "style_example",
-                                                        e.target.value,
-                                                    );
-                                                }}
-                                                className="textarea-style"
-                                                placeholder="Enter an example of how this field should be formatted..."
-                                                rows={4}
-                                            />
-                                        </Box>
-                                    </Tooltip>
-
-                                    <Tooltip label="Rules for refining the AI's response">
-                                        <Box width="full">
-                                            <Text fontSize="sm" mb={1}>
-                                                Refinement Rules
-                                            </Text>
-                                            <Select
-                                                size="sm"
-                                                className="input-style"
-                                                value={
-                                                    field.refinement_rules ||
-                                                    "default"
-                                                }
-                                                onChange={(e) =>
-                                                    updateField(
-                                                        idx,
-                                                        "refinement_rules",
-                                                        e.target.value,
-                                                    )
-                                                }
-                                            >
-                                                <option value="default">
-                                                    Default Rules
-                                                </option>
-                                                <option value="custom">
-                                                    Custom Rules
-                                                </option>
-                                            </Select>
-                                        </Box>
-                                    </Tooltip>
-                                </VStack>
-                            </Collapse>
-                        </Box>
-                    </>
-                )}
+                                </Box>
+                            </Tooltip>
+                        </VStack>
+                    </Collapse>
+                </Box>
             </VStack>
         </Box>
     );

--- a/src/components/settings/TemplateEditor.js
+++ b/src/components/settings/TemplateEditor.js
@@ -417,6 +417,32 @@ const FieldEditor = ({ field, idx, updateField, removeField }) => {
                                             )}
                                         </Box>
                                     </Tooltip>
+
+                                    {/* Add the new Style Example field here */}
+                                    <Tooltip label="Example of how this field should look">
+                                        <Box width="full">
+                                            <Text fontSize="sm" mb={1}>
+                                                Style Example
+                                            </Text>
+                                            <Textarea
+                                                size="sm"
+                                                value={
+                                                    field.style_example || ""
+                                                }
+                                                onChange={(e) => {
+                                                    updateField(
+                                                        idx,
+                                                        "style_example",
+                                                        e.target.value,
+                                                    );
+                                                }}
+                                                className="textarea-style"
+                                                placeholder="Enter an example of how this field should be formatted..."
+                                                rows={4}
+                                            />
+                                        </Box>
+                                    </Tooltip>
+
                                     <Tooltip label="Rules for refining the AI's response">
                                         <Box width="full">
                                             <Text fontSize="sm" mb={1}>
@@ -498,6 +524,7 @@ const TemplateEditor = ({ isOpen, onClose, template, templateKey, onSave }) => {
                     initial_prompt: "",
                     format_schema: null,
                     refinement_rules: "default",
+                    style_example: "",
                 },
             ],
         }));

--- a/src/utils/templates/templateService.js
+++ b/src/utils/templates/templateService.js
@@ -28,6 +28,7 @@ export const templateService = {
             throw error;
         }
     },
+
     setDefaultTemplate: async (templateKey, toast) => {
         try {
             await settingsApi.setDefaultTemplate(templateKey);
@@ -67,6 +68,42 @@ export const templateService = {
             return template;
         } catch (error) {
             console.error(`Failed to fetch template ${templateKey}:`, error);
+            throw error;
+        }
+    },
+
+    isDefaultTemplate: (templateKey) => {
+        const DEFAULT_TEMPLATE_KEYS = ["phlox_", "soap_", "progress_"];
+        return DEFAULT_TEMPLATE_KEYS.some((prefix) =>
+            templateKey.startsWith(prefix),
+        );
+    },
+
+    // Add a function to delete a template
+    deleteTemplate: async (templateKey) => {
+        try {
+            const response = await fetch(`/api/templates/${templateKey}`, {
+                method: "DELETE",
+            });
+
+            if (!response.ok) {
+                const errorData = await response
+                    .json()
+                    .catch(() => ({ message: "Unknown error" }));
+                throw new Error(
+                    errorData.message ||
+                        `Failed to delete template: ${response.status}`,
+                );
+            }
+
+            // Remove from cache if it exists
+            if (templateCache.has(templateKey)) {
+                templateCache.delete(templateKey);
+            }
+
+            return true;
+        } catch (error) {
+            console.error(`Failed to delete template ${templateKey}:`, error);
             throw error;
         }
     },


### PR DESCRIPTION
This PR adds a new `style_example` field to template fields, allowing users to provide examples of their preferred formatting style. This helps the LLM produce more consistently formatted medical notes that match each user's documentation preferences

## Deprecation Notice
The legacy `refinement_rules` approach is now deprecated in favor of the new style-based approach. While currently supported for backward compatibility, `refinement_rules` will be removed in a future release. Users should migrate to using `style_example` instead.